### PR TITLE
Make clojail compatible with Clojure version 1.5-1.7

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,10 +3,12 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :url "https://github.com/flatland/clojail"
-  :dependencies [[org.clojure/clojure "1.4.0"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
                  [bultitude "0.1.6"]
                  [serializable-fn "1.1.3"]
                  [org.flatland/useful "0.9.3"]]
-  :aliases {"testall" ["with-profile" "dev,1.5:dev" "test"]}
-  :profiles {:1.5 {:dependencies [[org.clojure/clojure "1.5.0-RC16"]]}}
+  :aliases {"testall" ["with-profile" "dev,1.5:dev,1.6:dev,1.7:dev" "test"]}
+  :profiles {:1.5 {:dependencies [[org.clojure/clojure "1.5.0-RC16"]]}
+             :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
+             :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}}
   :jvm-opts ["-Djava.security.policy=example.policy"])

--- a/test/clojail/core_test.clj
+++ b/test/clojail/core_test.clj
@@ -33,8 +33,8 @@
 
 (deftest macroexpand-test
   (is (= 'let (sb '(first '(let [x 1] x)))))
-  (is (= '(dec (clojure.core/-> x inc))
-         (sb '(macroexpand '(-> x inc dec)))))
+  (is (= '(inc x))
+         (sb '(macroexpand '(-> x inc))))
   (is (= 1 (sb '(-> 0 inc dec inc))))
   (is (= '(. "" length) (sb ''(. "" length)))))
 


### PR DESCRIPTION
Implement profiles for each version, and add to testall alias to simplify cross
version testing.

Update one test for cross-compatibility. The threading macro `->` was changed
to output a complete result instead of a recursive definition in terms of `->`
in Clojure 1.6. See [this patch](http://dev.clojure.org/jira/browse/CLJ-1121).
